### PR TITLE
Adding missing future package requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests == 2.10.0
 PythonConfluenceAPI == 0.0.1rc6
 boltons==16.4.1
+future==0.15.2


### PR DESCRIPTION
This may solved a missing requirement error:

`ImportError: No module named future`
