### PR TITLE
Fix #14

### DIFF
--- a/copier.py
+++ b/copier.py
@@ -74,15 +74,15 @@ class ConfluencePageCopier(object):
 
         # ancestor_id determines parent of the page being copied. If it's not provided, we take it from source page.
         # If source page doesn't have ancestors, that means that it's root page, so we will copy to the root as well.
-        if not ancestor_id:
-            if source['ancestors'] and source['space']['key'] == dst_space_key:
-                self.log.debug('Setting ancestor id to {}'.format(source['ancestors'][0]['id']))
-                ancestor_id = source['ancestors'][0]['id']
-            elif dst_parent_id is not None:
+        if ancestor_id is None:
+            if dst_parent_id is not None:
                 ancestor_id = dst_parent_id
             elif dst_parent_title is not None:
                 dst_parent = self._find_page(space_key=dst_space_key, title=dst_parent_title)
                 ancestor_id = dst_parent['id']
+            elif 'ancestors' in source and source['space']['key'] == dst_space_key:
+                self.log.debug('Setting ancestor id to {}'.format(source['ancestors'][-1]['id']))
+                ancestor_id = source['ancestors'][-1]['id']
             else:
                 ancestor_id = None
 

--- a/test_copier.py
+++ b/test_copier.py
@@ -1,0 +1,40 @@
+import unittest
+import sys, os
+from mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from copier import ConfluencePageCopier
+
+class TestOverwrite(unittest.TestCase):
+
+    @classmethod
+    def _find_page(cls, **kwargs):
+        return kwargs
+
+    def setUp(self):
+        self.source = {'title': 'source', 'content_id': 11, 'id': 2,'space': {'key': 'space'}}
+        self.dst = {'title': 'title', 'space_key': 'space'}
+        self.cp = ConfluencePageCopier('user','password','bah')
+        self.cp._find_page = MagicMock(side_effect=TestOverwrite._find_page)
+        self.cp._init_destination_page = MagicMock(return_value=[self.dst['space_key'], self.dst['title']])
+        self.cp._client.get_content_children_by_type = MagicMock(return_value={})
+        self.cp._overwrite_page = MagicMock()
+
+    def test_dst_parent_id(self):
+        ancestor = 3
+        self.cp.copy(src=self.source, dst_parent_id=ancestor, dst_title_template='', overwrite=True,
+                     skip_attachments=True, skip_labels=True)
+
+        self.cp._overwrite_page.assert_called_with(self.source, ancestor, self.dst, self.dst['space_key'],
+                                                   self.dst['title'])
+
+    def test_ancesor_id_page(self):
+        ancestor = 30
+        self.source['ancestors'] = [{'id': ancestor+2}, {'id': ancestor+1}, {'id': ancestor}]
+        self.cp.copy(src=self.source, dst_title_template='', overwrite=True,
+                     skip_attachments=True, skip_labels=True)
+        self.cp._overwrite_page.assert_called_with(self.source, ancestor, self.dst, self.dst['space_key'],
+                                                   self.dst['title'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Change priority of parent id to: dst_parent_id > dst_parent_title > source
ancestors
Basic Parent id unit tests
Get last source page ancestor instead of first. Last is the direct ancestor,
but first is root page in space.
